### PR TITLE
dotnet:1-sdk and README update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:latest
+FROM microsoft/dotnet:1-sdk
 COPY . /find-idle-instances
 WORKDIR /find-idle-instances
 RUN dotnet restore

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # find-idle-instances
-A small utility to identify instances which have been running idle and could be termianted. 
-Initially created to find Hudl servers that failed some aspect of signup and as in a 'stuck' state. 
+A small utility to identify instances which have been running idle and could be termianted.
+Initially created to find Hudl servers that failed some aspect of signup and as in a 'stuck' state.
 
-After build the application can be run with `.\find-idle-instances` . 
+After build the application can be run with `.\find-idle-instances` .
 
 Help on commands is built into the command line parser. For example `.\find-idle-instances help find` will show options for the 'find' command.
-For all commands `--accesskey`, `--secretkey`, `--name` are required. 
+For all commands `--accesskey`, `--secretkey`, `--name` are required.
 Name is a search string on the AWS property `tag:Name`. Examples are "\*" (for all servers) or "prod-farm-stream\*" for all servers of a particular group
 
 # Run with Docker
 `docker build -t <name> .`
 
 Finding instances - `docker run <name> find --accesskey #### --secretkey ##### --name <workerType>`
+Rebooting instances - `docker run -i -t <name> reboot --accesskey #### --secretkey ##### --name <workerType>`


### PR DESCRIPTION
This updates the Dockerfile to require dotnet:1-sdk instead of latest. Was seeing this before:
```
➜ docker run find-idle-instances find --accesskey ### --secretkey ### --name ### --securityGroup ###
Using launch settings from /find-idle-instances/Properties/launchSettings.json...
The launch profile "(Default)" could not be applied.
A usable launch profile could not be located.
It was not possible to find any compatible framework version
The specified framework 'Microsoft.NETCore.App', version '1.0.4' was not found.
  - Check application dependencies and target a framework version installed at:
      /
  - Alternatively, install the framework version '1.0.4'.
```

Also, added a sample `reboot` command to the README based on my macOS run for other first-time docker users :) Without the interactive and pseudo-tty I was seeing an error at the y/n prompt:
```
➜ docker run find-idle-instances reboot --accesskey ### --secretkey ### --name ### --securityGroup ###
Running (###)...

...info here...

Reboot Instances? (y/n)  

Unhandled Exception: System.AggregateException: One or more errors occurred. (Cannot read keys when either application does not have a console or when console input has been redirected. Try Console.Read.) ---> System.InvalidOperationException: Cannot read keys when either application does not have a console or when console input has been redirected. Try Console.Read.
   at System.ConsolePal.ReadKey(Boolean intercept)
   at System.Console.ReadKey()
   at FixStuckWorkers.Program.<>c__DisplayClass38_3.<<Main>b__6>d.MoveNext()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Microsoft.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at FixStuckWorkers.Program.Main(String[] args)
```