### PR TITLE
Also look for zombie cpu

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -350,13 +350,11 @@ namespace FixStuckWorkers
                 else if (max < MaxBadCpuPercent)
                 {
                     // if the CPU is basically doing nothing
-                    //Console.WriteLine($"LOW  {instance.Hostname}\tMax={max}, Avg={avg}, StdDev={stdDev}");
                     instanceResults.BadInstances.Add(new InstanceResult(instance, "Low CPU", max));
                 }
                 else if (max > MinStalledCpuPercent && stdDev < MaxStdDevStalledCpuPercent)
                 {
                     // if the CPU is above a floor (MinStalledCpuPercent) but is essentially flatlined
-                    //Console.WriteLine($"FLAT {instance.Hostname}\tMax={max}, Avg={avg}, StdDev={stdDev}");
                     instanceResults.BadInstances.Add(new InstanceResult(instance, "Flatlined CPU", stdDev));
                 }
                 else

--- a/Program.cs
+++ b/Program.cs
@@ -35,14 +35,13 @@ namespace FixStuckWorkers
         public string Name => $"{InstanceDescription.InstanceId} - {InstanceDescription.Hostname}";
         public InstanceDescription InstanceDescription { get; private set; }
         public double Cpu { get; private set; }
-        public InstanceResult(InstanceDescription instanceDescription, double cpu)
+        public string Reason { get; private set; }
+
+        public InstanceResult(InstanceDescription instanceDescription, string reason, double cpu)
         {
             InstanceDescription = instanceDescription;
             Cpu = cpu;
-        }
-        public override string ToString()
-        {
-            return Name + "\t\t\t" + Cpu.ToString("0.00");
+            Reason = reason;
         }
     }
 
@@ -74,6 +73,8 @@ namespace FixStuckWorkers
     {
         private const double MaxBadCpuPercent = 1.0;
         private const double UnknownCpuPercent = -1;
+        private const double MinStalledCpuPercent = 5.0;
+        private const double MaxStdDevStalledCpuPercent = 0.05;
         private const int MaxMetricConcurrency = 8;
         private const int MetricRetrievalInHours = 3;
         private const int PeriodInMinutes = 10;
@@ -315,19 +316,52 @@ namespace FixStuckWorkers
                     Period = (int)TimeSpan.FromMinutes(PeriodInMinutes).TotalSeconds,
                 };
                 var response = await cwClient.GetMetricStatisticsAsync(request);
-                var max = response.Datapoints.Count < MinServerMetricsToJudge ? UnknownCpuPercent : response.Datapoints.Max(p => p.Average);
+                var max = UnknownCpuPercent;
+                var avg = 0.0d;
+                var stdDev = 0.0d;
+                var count = response.Datapoints.Count;
+                if (count >= MinServerMetricsToJudge)
+                {
+                    // first loop to calculate max and sum
+                    var sum = 0.0d;
+                    foreach (var dp in response.Datapoints)
+                    {
+                        if (dp.Average > max)
+                        {
+                            max = dp.Average;
+                        }
+                        sum += dp.Average;
+                    }
+                    avg = sum / count;
+
+                    // second loop allows us to calculate std deviation
+                    var varianceSum = 0.0d;
+                    foreach (var dp in response.Datapoints)
+                    {
+                        varianceSum += Math.Pow(dp.Average - avg, 2.0d);
+                    }
+                    stdDev = Math.Sqrt(varianceSum / count);
+                }
 
                 if (max == UnknownCpuPercent)
                 {
-                    instanceResults.UnknownInstances.Add(new InstanceResult(instance, max));
+                    instanceResults.UnknownInstances.Add(new InstanceResult(instance, "Unknown CPU", max));
                 }
                 else if (max < MaxBadCpuPercent)
                 {
-                    instanceResults.BadInstances.Add(new InstanceResult(instance, max));
+                    // if the CPU is basically doing nothing
+                    //Console.WriteLine($"LOW  {instance.Hostname}\tMax={max}, Avg={avg}, StdDev={stdDev}");
+                    instanceResults.BadInstances.Add(new InstanceResult(instance, "Low CPU", max));
+                }
+                else if (max > MinStalledCpuPercent && stdDev < MaxStdDevStalledCpuPercent)
+                {
+                    // if the CPU is above a floor (MinStalledCpuPercent) but is essentially flatlined
+                    //Console.WriteLine($"FLAT {instance.Hostname}\tMax={max}, Avg={avg}, StdDev={stdDev}");
+                    instanceResults.BadInstances.Add(new InstanceResult(instance, "Flatlined CPU", stdDev));
                 }
                 else
                 {
-                    instanceResults.GoodInstances.Add(new InstanceResult(instance, max));
+                    instanceResults.GoodInstances.Add(new InstanceResult(instance, null, max));
                 }
 
                 var processed = instanceResults.BadInstances.Count + instanceResults.UnknownInstances.Count +
@@ -378,42 +412,75 @@ namespace FixStuckWorkers
 
         private static void DisplayInstanceResults(InstanceResults results)
         {
-            Console.WriteLine("");
+            var hasBadInstances = results.BadInstances != null && results.BadInstances.Count > 0;
+            if (ShowGoodInstances || ShowUnknownInstances || hasBadInstances)
+            {
+                Console.WriteLine("");
+            }
             if (ShowGoodInstances)
             {
                 Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine("Good Instances ({0})\t\t\t\t\t\t\t\tCPU%", results.GoodInstances.Count);
+                WriteStat($"Good Instances ({results.GoodInstances.Count})", "CPU%");
                 Console.WriteLine("=====================================================================================");
                 foreach (var result in results.GoodInstances)
                 {
-                    Console.WriteLine(result);
+                    WriteStat(result.Name, result.Cpu);
                 }
                 Console.WriteLine("");
             }
             if (ShowUnknownInstances)
             {
                 Console.ForegroundColor = ConsoleColor.Cyan;
-                Console.WriteLine("Unknown Instances ({0})\t\t\t\t\t\t\t\tCPU%", results.UnknownInstances.Count);
+                WriteStat($"Unknown Instances ({results.UnknownInstances.Count})", "CPU%");
                 Console.WriteLine("=================================================================================");
                 foreach (var result in results.UnknownInstances)
                 {
-
-                    Console.WriteLine(result);
+                    WriteStat(result.Name, result.Cpu);
                 }
                 Console.WriteLine("");
             }
 
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.WriteLine("Bad Instances ({0})\t\t\t\t\t\t\t\tCPU%", results.BadInstances.Count);
-            Console.WriteLine("=====================================================================================");
-            foreach (var result in results.BadInstances)
+            if (hasBadInstances)
             {
-                Console.WriteLine(result);
+                Console.ForegroundColor = ConsoleColor.Red;
+                WriteStat($"Bad Instances ({results.BadInstances.Count})", "Reason", "CPU%");
+                Console.WriteLine("===================================================================================================");
+                foreach (var result in results.BadInstances)
+                {
+                    WriteStat(result.Name, result.Reason, result.Cpu);
+                }
+                Console.WriteLine("");
             }
-            Console.WriteLine("");
 
             Console.ForegroundColor = ConsoleColor.White;
+        }
 
+        private static void WriteStat(string label, double stat)
+        {
+            WriteStat(label, stat.ToString("##0.00"));
+        }
+
+        private static void WriteStat(string label, string stat)
+        {
+            Console.Write(label);
+            Console.CursorLeft = (85 - stat.Length);
+            Console.Write(stat);
+            Console.WriteLine();
+        }
+
+        private static void WriteStat(string label, string reason, double stat)
+        {
+            WriteStat(label, reason, stat.ToString("##0.00"));
+        }
+
+        private static void WriteStat(string label, string reason, string stat)
+        {
+            Console.Write(label);
+            Console.CursorLeft = 80;
+            Console.Write(reason);
+            Console.CursorLeft = (99 - stat.Length);
+            Console.Write(stat);
+            Console.WriteLine();
         }
 
         private static async Task TerminateInstances(List<InstanceResult> badInstances)

--- a/build-command.sh
+++ b/build-command.sh
@@ -2,6 +2,8 @@
 
 keys="$(grep -A2 'hudl_farm' ~/.aws/credentials | sed -n -e 's/aws_access_key_id=\([A-Z]*\)/--accesskey \1/p' -e 's/aws_secret_access_key=\([A-Z0-9a-z]*\)/ --secretkey \1/p' | sed '/\n$/!N;s/\n//')"
 
+usageOptions="{find|reboot} {stream|stream-med|stream-lrg|phoenix-autogen|phoenix-hls-clip|phoenix-privacy|phoenix-reel-concat|phoenix-html-effects|phoenix-timeline-item} {use1|apse2|euw1}"
+
 command="dotnet run"
 case "$1" in 
 find)
@@ -11,22 +13,15 @@ reboot)
 	command+=" reboot"
 	;;
 *)
-	echo $"Usage $0 {find|reboot} {stream|stream-med|stream-lrg|phoenix-reel-concat|phoenix-html-effects|phoenix-timeline-item} {use1|apse2|euw1}"
+	echo $"Usage $0 $usageOptions"
 	exit 1
 esac
 command+=" $keys "
 if [[ $2 =~ stream-* ]]; then
 	command+="--securityGroup prod-streamworker"
-elif [ "$2" = "phoenix-reel-concat" ]; then
-	command+="--securityGroup prod-phoenix-reel-concat"
-elif [ "$2" = "phoenix-timeline-item" ]; then
-	command+="--securityGroup prod-phoenix-timeline-item"
-elif [ "$2" = "phoenix-html-effects" ]; then
-	command+="--securityGroup prod-phoenix-html-effects"
+elif [[ $2 =~ phoenix-* ]]; then
+	command+="--securityGroup prod-$2"
 fi
-
-
-
 
 case "$2" in
 stream-lrg)
@@ -38,17 +33,11 @@ stream-med)
 stream)
 	command+=" --name prod-farm-stream"
 	;;
-phoenix-reel-concat)
-	command+=" --name prod-farm-phoenix-reel-concat"
-	;;
-phoenix-html-effects)
-	command+=" --name prod-farm-phoenix-html-effects"
-	;;
-phoenix-timeline-item)
-	command+=" --name prod-farm-phoenix-timeline-item"
+phoenix-*)
+	command+=" --name prod-farm-$2"
 	;;
 *)
-	echo $"Usage $0 {find|reboot} {stream|stream-med|stream-lrg|phoenix-reel-concat|phoenix-html-effects|phoenix-timeline-item} {use1|apse2|euw1}"
+	echo $"Usage $0 $usageOptions"
 	exit 1
 esac
 


### PR DESCRIPTION
Modified the algorithm that looks for 'bad instances'. Now it will flag an instances as bad if:
* The avg CPU utilization is very low (not changed, it always did this), OR
* The avg CPU utilization is > 5% but the standard deviation of CPU utilization is less than 0.05%. This will identify stalled Phoenix workers who will get stuck at like 12 or 50% CPU utilization for days/weeks at a time. In my testing, healthy workers had standard deviation values of 1-20, well above the threshold set of 0.05.

Just like before, it will only look at instances with at least 1 hour of CPU utilization data.